### PR TITLE
feat: ナレッジ更新用のRepository、Controller、POSTルーティングを実装

### DIFF
--- a/src/controllers/edit-knowledge-page.controller.tsx
+++ b/src/controllers/edit-knowledge-page.controller.tsx
@@ -1,0 +1,43 @@
+import { KnowledgeRepository } from '../models/knowledge.repository.js';
+
+/**
+ * 編集画面のHTMLを生成するコントローラー
+ * @param userId ログイン中のユーザーID
+ * @param knowledgeId 編集対象のナレッジID
+ */
+export async function editKnowledgePageController(userId: string, knowledgeId: string): Promise<string> {
+  // 1. 既存のデータを取得する
+  const knowledge = await KnowledgeRepository.getByKnowledgeId(knowledgeId);
+
+  if (!knowledge) {
+    throw new Error('指定されたナレッジが見つかりません。');
+  }
+
+  // 2. 認可チェック：自分が投稿したナレッジか確認する
+  if (knowledge.authorId !== userId) {
+    throw new Error('このナレッジを編集する権限がありません。');
+  }
+
+  // 3. 本文データをフォームの初期値に入れてHTML（文字列）を返す
+  // ※ ここは既存の一覧画面などの実装（JSXやテンプレート）に合わせて適宜調整してください
+  return (
+    <div>
+      <h1>ナレッジの編集</h1>
+      <form action={`/knowledges/${knowledge.knowledgeId}/edit`} method="post">
+        <div>
+          <label htmlFor="content">本文 (Markdown)</label>
+          <textarea
+            id="content"
+            name="content"
+            rows={10}
+            style={{ width: '100%', display: 'block', marginBottom: '10px' }}
+          >
+            {knowledge.content}
+          </textarea>
+        </div>
+        <button type="submit">更新する</button>
+      </form>
+      <a href="/">キャンセル</a>
+    </div>
+  ); // プロジェクトがJSXを文字列に変換する設定（Honoのhtmlなど）になっていればこれで動きます
+}

--- a/src/controllers/update-knowledge.controller.tsx
+++ b/src/controllers/update-knowledge.controller.tsx
@@ -1,5 +1,5 @@
 import { KnowledgeRepository } from '../models/knowledge.repository.js';
-import type { Knowledge } from '../models/knowledge.model.js';
+import { Knowledge } from '../models/knowledge.model.js';
 
 interface UpdateInput {
   title: string;
@@ -33,7 +33,6 @@ export async function updateKnowledgeController(
   // 3. データを上書きして upsert を呼ぶ
   const updatedKnowledge: Knowledge = {
     ...currentKnowledge,
-    title: input.title,
     content: input.content,
     // updatedAt: new Date().toISOString() // もし更新日時の項目があれば入れる
   };

--- a/src/controllers/update-knowledge.controller.tsx
+++ b/src/controllers/update-knowledge.controller.tsx
@@ -1,0 +1,42 @@
+import { KnowledgeRepository } from '../models/knowledge.repository.js';
+import type { Knowledge } from '../models/knowledge.model.js';
+
+interface UpdateInput {
+  title: string;
+  content: string;
+}
+
+/**
+ * ナレッジを更新するコントローラー
+ * @param userId ログイン中のユーザーID
+ * @param knowledgeId 更新対象のナレッジID
+ * @param input フォームから送られてきた新しいタイトルと本文
+ */
+export async function updateKnowledgeController(
+  userId: string,
+  knowledgeId: string,
+  input: UpdateInput
+): Promise<void> {
+  // 1. 他の子が作ってくれた getByKnowledgeId を使って、今のデータを取得する
+  const currentKnowledge = await KnowledgeRepository.getByKnowledgeId(knowledgeId);
+
+  if (!currentKnowledge) {
+    throw new Error('指定されたナレッジが見つかりません。');
+  }
+
+  // 2. 認可チェック：自分が投稿したナレッジか確認する
+  // ※ knowledge.model.ts の定義に合わせて、必要なら authorId などのプロパティ名に調整してください
+  if (currentKnowledge.authorId !== userId) {
+    throw new Error('このナレッジを編集する権限がありません。');
+  }
+
+  // 3. データを上書きして upsert を呼ぶ
+  const updatedKnowledge: Knowledge = {
+    ...currentKnowledge,
+    title: input.title,
+    content: input.content,
+    // updatedAt: new Date().toISOString() // もし更新日時の項目があれば入れる
+  };
+
+  await KnowledgeRepository.upsert(updatedKnowledge);
+}

--- a/src/models/knowledge.repository.ts
+++ b/src/models/knowledge.repository.ts
@@ -1,5 +1,4 @@
-import { glob, readFile } from 'node:fs/promises';
-
+import { glob, readFile, writeFile } from 'node:fs/promises'; 
 import type { Knowledge } from './knowledge.model.js';
 
 async function getAll(): Promise<Knowledge[]> {
@@ -8,6 +7,16 @@ async function getAll(): Promise<Knowledge[]> {
   const knowledges = await Promise.all(files.map((file) => readFile(file, 'utf-8').then(JSON.parse)));
 
   return knowledges;
+}
+
+async function upsert(knowledge: Knowledge): Promise<void> {
+  // パスを「./storage/ナレッジID.json」にする
+  const filePath = `./storage/${knowledge.knowledgeId}.json`;
+  
+  // JSONオブジェクトを文字列に変換してファイルに書き込む（インデント2スペースで見やすく）
+  const data = JSON.stringify(knowledge, null, 2);
+  
+  await writeFile(filePath, data, 'utf-8');
 }
 
 export const KnowledgeRepository = {
@@ -19,8 +28,7 @@ export const KnowledgeRepository = {
 
   getAll,
 
-  // biome-ignore lint/suspicious/noExplicitAny: TODO: (学生向け) 実装する
-  upsert: (_: Knowledge): Promise<void> => undefined as any,
+  upsert,
 
   // biome-ignore lint/suspicious/noExplicitAny: TODO: (学生向け) 実装する
   deleteByKnowledgeId: (_: string): Promise<void> => undefined as any,

--- a/src/router.ts
+++ b/src/router.ts
@@ -20,16 +20,16 @@ router.get('/', (ctx) => {
 router.post('/knowledges/:id/edit', async (ctx) => {
   const userId = ctx.get('userId');
   const knowledgeId = ctx.req.param('id');
-  
+
   // フォームから送信されたデータ（title, content）を受け取る
   const body = await ctx.req.parseBody();
-  const title = String(body.title);
-  const content = String(body.content);
+  const title = String(body['title']);
+  const content = String(body['content']);
 
   try {
     // 作成した Controller を呼び出す
     await updateKnowledgeController(userId, knowledgeId, { title, content });
-    
+
     // 更新が成功したら、トップページ（一覧）か詳細ページにリダイレクトする
     return ctx.redirect('/');
   } catch (error) {

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { getAllKnowledgesController } from './controllers/get-all-knowledges.controller.js';
+import { updateKnowledgeController } from './controllers/update-knowledge.controller.js';
 
 export interface Variables {
   userId: string;
@@ -14,4 +15,26 @@ router.get('/', (ctx) => {
 
   // MEMO: Controller は Context を直接受け取らず、必要な情報のみを引数に受け取る
   return ctx.html(getAllKnowledgesController(userId));
+});
+
+router.post('/knowledges/:id/edit', async (ctx) => {
+  const userId = ctx.get('userId');
+  const knowledgeId = ctx.req.param('id');
+  
+  // フォームから送信されたデータ（title, content）を受け取る
+  const body = await ctx.req.parseBody();
+  const title = String(body.title);
+  const content = String(body.content);
+
+  try {
+    // 作成した Controller を呼び出す
+    await updateKnowledgeController(userId, knowledgeId, { title, content });
+    
+    // 更新が成功したら、トップページ（一覧）か詳細ページにリダイレクトする
+    return ctx.redirect('/');
+  } catch (error) {
+    // もし他人の記事だったりしてエラーが出た場合のハンドリング
+    ctx.status(403);
+    return ctx.html(`<h1>エラー</h1><p>${(error as Error).message}</p>`);
+  }
 });

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { editKnowledgePageController } from './controllers/edit-knowledge-page.controller.js';
 import { getAllKnowledgesController } from './controllers/get-all-knowledges.controller.js';
 import { updateKnowledgeController } from './controllers/update-knowledge.controller.js';
 
@@ -15,6 +16,19 @@ router.get('/', (ctx) => {
 
   // MEMO: Controller は Context を直接受け取らず、必要な情報のみを引数に受け取る
   return ctx.html(getAllKnowledgesController(userId));
+});
+
+router.get('/knowledges/:id/edit', async (ctx) => {
+  const userId = ctx.get('userId');
+  const knowledgeId = ctx.req.param('id');
+
+  try {
+    const html = await editKnowledgePageController(userId, knowledgeId);
+    return ctx.html(html);
+  } catch (error) {
+    ctx.status(404);
+    return ctx.html(`<h1>エラー</h1><p>${(error as Error).message}</p>`);
+  }
 });
 
 router.post('/knowledges/:id/edit', async (ctx) => {


### PR DESCRIPTION
## 概要
ナレッジ更新（Update）機能のバックエンド処理およびPOSTルーティングの実装を行いました。

## 変更内容
- **Repository層**: `upsert` 関数を実装し、指定したIDのJSONファイルへ上書き保存できるように対応
- **Controller層**: `updateKnowledgeController` を実装し、既存データの取得、投稿者本人の認可判定（`authorId === userId`）、更新ロジックを統合
- **Router層**: 更新用リクエスト（POST `/knowledges/:id/edit`）のルーティングを追加

## 次にやること（作業中）
- 編集用フォームを表示するGETルーティングの実装
- UI（編集画面）の作成