### PR TITLE
feat: ナレッジ詳細機能を実装

### DIFF
--- a/src/controllers/get-knowledge.controller.tsx
+++ b/src/controllers/get-knowledge.controller.tsx
@@ -1,0 +1,10 @@
+import type { Child } from 'hono/jsx';
+import { KnowledgeDetailFeature } from '../features/KnowledgeDetailFeature.js';
+import { KnowledgeRepository } from '../models/knowledge.repository.js';
+export async function getKnowledgeController(knowledgeId: string): Promise<Child> {
+  const knowledge = await KnowledgeRepository.getByKnowledgeId(knowledgeId);
+  if (!knowledge) {
+    return <div>指定されたナレッジが見つかりませんでした。</div>;
+  }
+  return <KnowledgeDetailFeature knowledge={knowledge} />;
+}

--- a/src/features/CreateKnowledgeFeature.tsx
+++ b/src/features/CreateKnowledgeFeature.tsx
@@ -1,0 +1,61 @@
+import type { Child } from 'hono/jsx';
+
+interface CreateKnowledgeFeatureProps {
+  userId: string;
+}
+
+// 💡 userId の警告を消すため、一旦 {} にしています
+// 💡 引数の {} を props に変更し、中身の label に htmlFor を追加して input と紐付けます
+
+export function CreateKnowledgeFeature(_props: CreateKnowledgeFeatureProps): Child {
+  return (
+    <div className="max-w-2xl mx-auto p-6 bg-white rounded-lg shadow-md mt-10">
+      <h1 className="text-2xl font-bold text-gray-800 mb-6">ナレッジの新規作成</h1>
+
+      <form action="/knowledges" className="space-y-4" method="post">
+        <div>
+          {/* 💡 htmlFor="title" を追加 */}
+          <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="title">
+            タイトル
+          </label>
+          <input
+            className="w-full border border-gray-300 rounded-md p-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none"
+            id="title" // 💡 id="title" を追加して label と紐付ける
+            name="title"
+            required
+            type="text"
+          />
+        </div>
+
+        <div>
+          {/* 💡 htmlFor="content" を追加 */}
+          <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="content">
+            本文
+          </label>
+          <textarea
+            className="w-full border border-gray-300 rounded-md p-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none"
+            id="content" // 💡 id="content" を追加して label と紐付ける
+            name="content"
+            required
+            rows={5}
+          />
+        </div>
+
+        <div className="flex justify-end space-x-3 pt-4">
+          <a
+            className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 transition"
+            href="/"
+          >
+            キャンセル
+          </a>
+          <button
+            className="px-4 py-2 bg-blue-600 border border-transparent rounded-md text-sm font-medium text-white hover:bg-blue-700 transition shadow-sm"
+            type="submit"
+          >
+            投稿する
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/features/KnowledgeDetailFeature.tsx
+++ b/src/features/KnowledgeDetailFeature.tsx
@@ -1,0 +1,22 @@
+import type { Knowledge } from '../models/knowledge.model.js';
+
+interface Props {
+  knowledge: Knowledge;
+}
+export function KnowledgeDetailFeature({ knowledge }: Props) {
+  return (
+    <div style={{ padding: '20px', maxWidth: '600px', margin: '0 auto' }}>
+      {/* 💡 title を削り、ナレッジのIDか「ナレッジ詳細」と表示させます */}
+      <h1>ナレッジ詳細</h1>
+      <p style={{ color: '#666', fontSize: '14px' }}>ID: {knowledge.knowledgeId}</p>
+      <hr />
+
+      {/* 💡 本文（content）を表示します */}
+      <p style={{ whiteSpace: 'pre-wrap', marginTop: '20px' }}>{knowledge.content}</p>
+
+      <a href="/" style={{ display: 'block', marginTop: '40px', color: '#0070f3' }}>
+        ← トップページに戻る
+      </a>
+    </div>
+  );
+}

--- a/src/models/knowledge.repository.ts
+++ b/src/models/knowledge.repository.ts
@@ -11,8 +11,11 @@ async function getAll(): Promise<Knowledge[]> {
 }
 
 export const KnowledgeRepository = {
-  // biome-ignore lint/suspicious/noExplicitAny: TODO: (学生向け) 実装する
-  getByKnowledgeId: (_: string): Promise<Knowledge> => undefined as any,
+  getByKnowledgeId: async (knowledgeId: string): Promise<Knowledge | null> => {
+    const allknowledges = await getAll();
+    const found = allknowledges.find((k) => k.knowledgeId === knowledgeId);
+    return found ?? null;
+  },
 
   // biome-ignore lint/suspicious/noExplicitAny: TODO: (学生向け) 実装する
   getByAuthorId: (_: string): Promise<Knowledge[]> => undefined as any,

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { getAllKnowledgesController } from './controllers/get-all-knowledges.controller.js';
+import { getKnowledgeController } from './controllers/get-knowledge.controller.js';
 
 export interface Variables {
   userId: string;
@@ -14,4 +15,23 @@ router.get('/', (ctx) => {
 
   // MEMO: Controller は Context を直接受け取らず、必要な情報のみを引数に受け取る
   return ctx.html(getAllKnowledgesController(userId));
+});
+
+// 既存の router.get('/', ...) の下に追加します
+// 1. 新しい記事を「投稿（POST）」するための受付窓口
+// 💡 末尾にスラッシュをつけて '/knowledges/' にするか、または一旦コメントアウトするかですが、
+// ルーターの競合を防ぐために、以下のように綺麗に整えます。
+
+router.post('/knowledges/', async (ctx) => {
+  const body = await ctx.req.parseBody();
+  console.log('送られてきたデータ:', body);
+  return ctx.redirect('/');
+});
+
+// 2. 詳細画面を表示する窓口
+// 💡 こちらもパスが正しく認識されるよう、以下のように書いてみてください。
+router.get('/knowledges/:knowledgeId', async (ctx) => {
+  const knowledgeId = ctx.req.param('knowledgeId');
+  const component = await getKnowledgeController(knowledgeId);
+  return ctx.html(component as never);
 });


### PR DESCRIPTION
## やったこと
- ナレッジ詳細表示機能の実装
  - URL `src/router.ts` に `/knowledges/:knowledgeId` のルーティングを追加
  - 詳細画面を管理するコントローラーを追加
  - 画面表示用のコンポーネントでナレッジ詳細データを表示できるように実装
- コード品質の向上とビルド確認
  - Biome によるコード規約チェックのエラー（HTMLアクセシビリティの `htmlFor` 不足、空オブジェクトパターンなど）の修正
  - `npm run build` を実行し、TypeScriptの型エラーや Tailwind CSS のビルドが正常に通ることを確認

## 不安な点・確認してほしいこと
- **詳細画面の型定義（Honoの `ctx.html` の戻り値）**
  - 最初、コントローラーの返すパーツの型が合わず型エラーが発生しました。
  - 現在は `as never`（または `html` テンプレートリテラル）を適用してビルドが通るようにしていますが、この型エラーの回避方法が設計として適切か、レビューでご確認いただきたいです。
- **ファイル権限の変更**
  - WSL環境での作業中に `CreateKnowledgeFeature.tsx` の書き込み権限エラー（EACCES）が発生したため、手動で `chmod`/`chown` を行いました。リポジトリ側の設定や他のメンバーの環境に影響が出ていないか少し不安です。